### PR TITLE
Fixed column name

### DIFF
--- a/lib/generators/circle/templates/migration.rb
+++ b/lib/generators/circle/templates/migration.rb
@@ -24,7 +24,7 @@ class CreateCircleTables < ActiveRecord::Migration
     end
 
     change_table :users do |t|
-      t.integer :friends_cout, :default => 0, :null => false
+      t.integer :friends_count, :default => 0, :null => false
     end
   end
 


### PR DESCRIPTION
The migration generator creates a column with incorrect spelling (friends_cout).  Changed it to friends_count.
